### PR TITLE
Explicitly-requires dropbs/breadcrumb_item.rb

### DIFF
--- a/_plugins/breadcrumbs.rb
+++ b/_plugins/breadcrumbs.rb
@@ -1,3 +1,5 @@
+require_relative 'dropbs/breadcrumb_item.rb'
+
 Jekyll::Hooks.register :pages, :pre_render do |page, payload|
   drop = Drops::BreadcrumbItem
 


### PR DESCRIPTION
Implicitly-requiring `dropbs/breadcrumb_item.rb` does not work on my system, so this requires it explicitly.
