### PR TITLE
Consider both pages and documents for breadcrumbs

### DIFF
--- a/_plugins/breadcrumbs.rb
+++ b/_plugins/breadcrumbs.rb
@@ -13,7 +13,8 @@ Jekyll::Hooks.register :pages, :pre_render do |page, payload|
 
     0.upto(pth.size - 1) do |int|
       joined_path = pth[0..int].join("/")
-      item = page.site.pages.find { |page_| joined_path == "" && page_.url == "/" || page_.url.chomp("/") == joined_path }
+      all_pages = [].concat(page.site.pages).concat(page.site.documents)
+      item = all_pages.find { |page_| joined_path == "" && page_.url == "/" || page_.url.chomp("/") == joined_path }
       payload["breadcrumbs"] << drop.new(item, payload) if item
     end
   end
@@ -32,7 +33,8 @@ Jekyll::Hooks.register :documents, :pre_render do |documents, payload|
 
     0.upto(pth.size - 1) do |int|
       joined_path = pth[0..int].join("/")
-      item = documents.site.documents.find { |documents| joined_path == "" && documents.url == "/" || documents.url.chomp("/") == joined_path }
+      all_pages = [].concat(documents.site.pages).concat(documents.site.documents)
+      item = all_pages.find { |page_| joined_path == "" && page_.url == "/" || page_.url.chomp("/") == joined_path }
       payload["breadcrumbs"] << drop.new(item, payload) if item
     end
   end


### PR DESCRIPTION
Fixes git-no/jekyll-breadcrumbs#3