### PR TITLE
Added a hash as a cache so each search for a url occurs only once.

### DIFF
--- a/site/_plugins/breadcrumbs.rb
+++ b/site/_plugins/breadcrumbs.rb
@@ -1,21 +1,43 @@
 require_relative 'drops/breadcrumb_item.rb'
 
-Jekyll::Hooks.register [:pages, :documents], :pre_render do |side, payload|  # documents are collections, and collections include also posts
-  drop = Drops::BreadcrumbItem
+module Jekyll
+  module Breadcrumbs
+    @@pages_cache = {}
+    def self.build_breadcrumb(side, payload)
+      drop = ::Drops::BreadcrumbItem
 
-  if side.url == "/"
-    then payload["breadcrumbs"] = [
-      drop.new(side, payload)
-    ]
-  else
-    payload["breadcrumbs"] = []
-    path = side.url.split("/")
+      if side.url == "/"
+        then
+        payload["breadcrumbs"] = [
+          drop.new(side, payload)
+        ]
+      else
+        payload["breadcrumbs"] = []
+        pth = side.url.split("/")
 
-    0.upto(path.size - 1) do |int|
-      joined_path = path[0..int].join("/")
-      sides = [].concat(side.site.pages).concat(side.site.documents)
-      item = sides.find { |side_| joined_path == "" && side_.url == "/" || side_.url.chomp("/") == joined_path }
-      payload["breadcrumbs"] << drop.new(item, payload) if item
+        sides = [].concat(side.site.pages).concat(side.site.documents)
+
+        0.upto(pth.size - 1) do |int|
+          joined_path = pth[0..int].join("/")
+
+          if @@pages_cache[joined_path] == nil
+          then
+            @@pages_cache[joined_path] = sides.find { |side_| joined_path == "" && side_.url == "/" || side_.url.chomp("/") == joined_path }
+            if @@pages_cache[joined_path] == nil
+            then
+              @@pages_cache[joined_path] = "nomatch"
+            end
+          end
+
+          item = @@pages_cache[joined_path]
+
+          payload["breadcrumbs"] << drop.new(item, payload) if item != "nomatch"
+        end
+      end
     end
+  end
+
+  Jekyll::Hooks.register [:pages, :documents], :pre_render do |side, payload|  # documents are collections, and collections include also posts
+    Breadcrumbs::build_breadcrumb(side, payload)
   end
 end

--- a/source/_plugins/breadcrumbs.rb
+++ b/source/_plugins/breadcrumbs.rb
@@ -1,21 +1,43 @@
 require_relative 'drops/breadcrumb_item.rb'
 
-Jekyll::Hooks.register [:pages, :documents], :pre_render do |side, payload|  # documents are collections, and collections include also posts
-  drop = Drops::BreadcrumbItem
+module Jekyll
+  module Breadcrumbs
+    @@pages_cache = {}
+    def self.build_breadcrumb(side, payload)
+      drop = Drops::BreadcrumbItem
 
-  if side.url == "/"
-    then payload["breadcrumbs"] = [
-      drop.new(side, payload)
-    ]
-  else
-    payload["breadcrumbs"] = []
-    path = side.url.split("/")
+      if side.url == "/"
+        then
+        payload["breadcrumbs"] = [
+          drop.new(side, payload)
+        ]
+      else
+        payload["breadcrumbs"] = []
+        pth = side.url.split("/")
 
-    0.upto(path.size - 1) do |int|
-      joined_path = path[0..int].join("/")
-      sides = [].concat(side.site.pages).concat(side.site.documents)
-      item = sides.find { |side_| joined_path == "" && side_.url == "/" || side_.url.chomp("/") == joined_path }
-      payload["breadcrumbs"] << drop.new(item, payload) if item
+        sides = [].concat(side.site.pages).concat(side.site.documents)
+
+        0.upto(pth.size - 1) do |int|
+          joined_path = pth[0..int].join("/")
+
+          if @@pages_cache[joined_path] == nil
+          then
+            @@pages_cache[joined_path] = sides.find { |side_| joined_path == "" && side_.url == "/" || side_.url.chomp("/") == joined_path }
+            if @@pages_cache[joined_path] == nil
+            then
+              @@pages_cache[joined_path] = "nomatch"
+            end
+          end
+
+          item = @@pages_cache[joined_path]
+
+          payload["breadcrumbs"] << drop.new(item, payload) if item != "nomatch"
+        end
+      end
     end
+  end
+
+  Jekyll::Hooks.register [:pages, :documents], :pre_render do |side, payload|  # documents are collections, and collections include also posts
+    Breadcrumbs::build_breadcrumb(side, payload)
   end
 end


### PR DESCRIPTION
I ran into problems with a site with very large number of pages (1000s) with deep urls. Each page with taking about 1-3 seconds to load. With the change it takes less than 1 second.

The change uses a hash to store hits and miss so each sides.find is only run once for each unique url.

I'm not a ruby dev so I don't guarantee the code quality but it works for me on the site I am building.